### PR TITLE
The prepare script adds all unstaged changes, commits (possibly empty…

### DIFF
--- a/root/bin/git-prepare.sh
+++ b/root/bin/git-prepare.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 
-if git refresh
-then
-    git checkout -b scratch_$(uuidgen) &&
-        COMMENT_COMMIT=$(git log --pretty=format:"%h" "upstream/${MASTER_BRANCH}"..HEAD | tail -n 1) &&
-        git reset --soft "upstream/${MASTER_BRANCH}" &&
-        git commit --reedit-message ${COMMENT_COMMIT}
-else
-    echo Failed to cleanly refresh &&
-        exit 64
-fi
+git commit --all --allow-empty --allow-empty-message &&
+    if git refresh
+    then
+        git checkout -b scratch_$(uuidgen) &&
+            COMMENT_COMMIT=$(git log --pretty=format:"%h" "upstream/${MASTER_BRANCH}"..HEAD | tail -n 1) &&
+            git reset --soft "upstream/${MASTER_BRANCH}" &&
+            git commit --reedit-message ${COMMENT_COMMIT}
+    else
+        echo Failed to cleanly refresh &&
+            exit 64
+    fi


### PR DESCRIPTION
…) with an empty commit message.

This supports the work flow that we write a commit message first (intention).
Then we do the work (implementation).  We commit as we work.
If the work is trivial, then we can skip the final commit.